### PR TITLE
Update ubiregi_api_scala's version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.ubiregi"
 
 name := "ubiregi_api_scala"
 
-version := "0.1.0"
+version := "0.2.0-SNAPSHOT"
 
 scalaVersion := "2.9.2"
 


### PR DESCRIPTION
- from 0.1.0 to 0.2.0-SNAPSHOT
